### PR TITLE
charts: Point to production image rather than staging image

### DIFF
--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -28,7 +28,7 @@ controllerManager:
         drop: ["ALL"]
   manager:
     image:
-      repository: us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue
+      repository: registry.k8s.io/kueue/kueue
       # This should be set to 'IfNotPresent' for released version      
       pullPolicy: Always
     podAnnotations: {}


### PR DESCRIPTION
Despite the [`kueue/charts/kueue/README.md`](https://github.com/kubernetes-sigs/kueue/tree/v0.10.2/charts/kueue#installing-the-chart) suggesting that it's OK to install `kueue` as a helm chart by using their repository, their repository actually uses a [staging image repository](https://github.com/kubernetes-sigs/kueue/issues/5067#issuecomment-2822082231) `us-central1-docker.pkg.dev/k8s-staging-images/kueue` rather than the repository `registry.k8s.io/kueue` they use for official releases. Maybe the README is meant to be read by devs, not users.

This caused issues for us when the `v0.10.2` tag disappeared from the staging repository `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue`, instead being replaced being replaced by tag names like `v20250319-v0.10.2-20-gc79419eb`. Then `kueue` was not able to pull its image, causing users to be unable to launch jobs. Incident report: https://farinc.slack.com/archives/C054KEQ0PPE/p1748388437045859

This PR points the kueue manager to use the official repository rather than the staging image repository.

Testing: I used `helmfile` to deploy `kueue` with the new image and the deployment worked.